### PR TITLE
fix: amazon images background color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1430,6 +1430,12 @@ span.milestone-bar_background {
 [class*="imageContainer"] img {
     mix-blend-mode: unset !important;
 }
+[data-pf=DESKTOP] [class*="img"] {
+    background-color: white;
+}
+[class*="productImageContainer"] {
+    background-color: white;
+}
 
 IGNORE INLINE STYLE
 .s-color-swatch-inner-circle-fill


### PR DESCRIPTION
Some images use the alpha channel as white, this PR fixes #12569